### PR TITLE
Yq dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
 # COMS4156
 This is the final project of COMS 4156, co-authored by four members from the class - JY, YW, RJ, and YQ.
 
+### March 30 2017 - Yulong Qiao & Ruijue Ji
+Last Day of Iteration 1, today's modifications:
+
+bug fixed:
+- two app.get() method in *index.js*: app.get('/books/:bookId/:chapterIdx') and app.get('/books/:bookId/uploadNewChapter') may **confuse** each other, rendering wrong page.
+Now the uploadNewChapter address change to '/books/:bookId/chapter/:chapterIdx', I think it's time to make rules that no two ':params' can be put adjacent to each other
+
+functions added:
+- former question: receive 404 when including js with src="../public/js/publish.js", fixed with src="../../public/js/publish.js"
+- to get rid redundant code
+  - every non-empty input tags a class "publish-non-empty" 
+  - every ejs with some non-empty inputs subscribes to publish.js 
+
 ### March 30 2017 - Jinyang Yu
 bug fix:
 - Cannot publish/edit an empty book name.

--- a/index.js
+++ b/index.js
@@ -299,7 +299,7 @@ app.post('/books/:bookId/update', function (req, res) {
 });
 
 // display chapter content in one book
-app.get('/books/:bookId/:chapterIdx', function (req, res) {
+app.get('/books/:bookId/chapter/:chapterIdx', function (req, res) {
     var chapterIdx = parseInt(req.params.chapterIdx);
     var bookId = req.params.bookId;
 

--- a/public/js/publish.js
+++ b/public/js/publish.js
@@ -1,8 +1,13 @@
-/* publish */
+/*
+ * publish.js functionality: ensure input with class="publish-non-empty" is not empty
+ * subscribed by:
+ *  * publish.ejs - when publishing book, bookname should not be empty
+ *  * uploadNewChapter.ejs - when uploading new chapter, chapter's name should not be empty
+ */
 $(document).ready(function () {
-    $('#submit-publish-form').click(function(e) {
+    $('#submit-publish-form,#new-chapter-submit').click(function(e) {
         var isValid = true;
-        $('input[type="text"]').each(function() {
+        $('input[type="text"].publish-non-empty').each(function() {
             if ($.trim($(this).val()) == '') {
                 isValid = false;
                 $(this).css({
@@ -23,9 +28,12 @@ $(document).ready(function () {
 });
 function empty() {
     var x;
-    x = document.getElementById("book-name").value;
-    if (x == "") {
-        alert("Book name cannot be empty!");
-        return false;
+    //since getElementsByClassName return nodelist
+    for (var i=0;i<document.getElementsByClassName('publish-non-empty').length;i++) {
+        x = document.getElementsByClassName('publish-non-empty')[i].value;
+        if (x == "") {
+            alert("Some fields can not be left empty");
+            return false;
+        }
     }
 }

--- a/views/chapter.ejs
+++ b/views/chapter.ejs
@@ -4,10 +4,10 @@
     <br>
     <label id="content">Content: <%=chapter.content%></label>
     <%if (parseInt(chapterIdx) != 0) {%>
-    <a href= <%= "/books/"+ bookId + '/' + (parseInt(chapterIdx) - 1).toString()%>>Previous Chapter</a>
+    <a href= <%= "/books/"+ bookId + '/chapter/' + (parseInt(chapterIdx) - 1).toString()%>>Previous Chapter</a>
     <%}%>
     <a href= <%= "/books/"+bookId%>>Return to Menu</a>
     <%if (parseInt(chapterIdx) != chapterMax) {%>
-    <a href= <%= "/books/"+ bookId + '/' + (parseInt(chapterIdx) + 1).toString()%>>Next Chapter</a>
+    <a href= <%= "/books/"+ bookId + '/chapter/' + (parseInt(chapterIdx) + 1).toString()%>>Next Chapter</a>
     <%}%>
 </div>

--- a/views/chapters.ejs
+++ b/views/chapters.ejs
@@ -55,7 +55,7 @@
             <th>
                 <% var chapterID= book.chapters[i].toString() %>
                 <p hidden id="parse-book-id"><%=bookID%></p>
-                <a href= <%= "/books/"+bookID +'/'+i %>> <%= book.chapters[i].title%></a></th>
+                <a href= <%= "/books/"+bookID +'/chapter/'+i %>> <%= book.chapters[i].title%></a></th>
         </tr>
         <% }} %>
         </tbody>

--- a/views/publish.ejs
+++ b/views/publish.ejs
@@ -2,7 +2,7 @@
 <form id="publish-book"  action="/publishBook" method="post">
     <div>
         <label>Book Name:</label>
-        <input id="book-name" type="text" name="bookname"/>
+        <input class="publish-non-empty" id="book-name" type="text" name="bookname"/>
     </div>
     <div>
         <label>Book Description:</label>

--- a/views/uploadNewChapter.ejs
+++ b/views/uploadNewChapter.ejs
@@ -1,19 +1,18 @@
+<a href=<%="/books/"+bookID%>>Back to this book's page</a>
 <p>Here you can upload a new chapter to your book</p>
 <form id="chapter-form" action="/service/uploadNewChapter" method="post">
     <div>
         <label>title:</label>
-        <input type="text" name="title"/>
+        <input class="publish-non-empty" id="chapter-title-input" type="text" name="title"/>
     </div>
     <div>
         <label>Content:</label>
         <textarea type="text" name="chapterContent"/></textarea>
     </div>
     <div>
-
         <input type="hidden" name="bookid" value="<%=bookID%>"/>
+        <input hidden type="text" name="bookid">
+        <input id="new-chapter-submit" type="submit" onclick="return empty()" class="btn btn-primary btn-sm" value="ChapterPublish"/>
     </div>
-    <div>
-        <input type="submit" class="btn btn-primary btn-sm" value="ChapterPublish"/>
-    </div>
-    <input hidden type="text" name="bookid">
 </form>
+<script type="text/javascript" src="../../public/js/publish.js" defer></script>


### PR DESCRIPTION
bug fixed:
- two app.get() method in *index.js*:
app.get('/books/:bookId/:chapterIdx') and
app.get('/books/:bookId/uploadNewChapter') may **confuse** each other,
rendering wrong page.
Now the uploadNewChapter address change to
'/books/:bookId/chapter/:chapterIdx', I think it's time to make rules
that no two ':params' can be put adjacent to each other

functions added:
- former question: receive 404 when including js with
src="../public/js/publish.js", fixed with
src="../../public/js/publish.js"
- to get rid redundant code
- every non-empty input tags a class "publish-non-empty"
- every ejs with some non-empty inputs subscribes to publish.js